### PR TITLE
Fix 400/405 API endpoint error between frontend and backend

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
+import { apiService } from './api/apiService';
 
 function App() {
   const [selectedAgents, setSelectedAgents] = useState([]);
@@ -110,31 +111,21 @@ function App() {
     setIsAnalyzing(true);
     
     try {
-      const response = await fetch(`${apiUrl}/input_task`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          session_id: `session_${Date.now()}`,
-          description: scenario
-        })
+      const response = await apiService.submitInputTask({
+        session_id: `session_${Date.now()}`,
+        description: scenario
       });
-
-      if (response.ok) {
-        const result = await response.json();
-        setAnalysis({
-          agent_responses: selectedAgents.map(agent => ({
-            agent_name: agent.name,
-            agent_expertise: agent.expertise,
-            response: `Echte AI analyse van ${agent.name}:\n\n${JSON.stringify(result, null, 2)}`
-          }))
-        });
-      } else {
-        alert('Fout: ' + response.status);
-      }
+      
+      setAnalysis({
+        agent_responses: selectedAgents.map(agent => ({
+          agent_name: agent.name,
+          agent_expertise: agent.expertise,
+          response: `Echte AI analyse van ${agent.name}:\n\n${JSON.stringify(response, null, 2)}`
+        }))
+      });
     } catch (error) {
-      alert('Backend fout: ' + error.message);
+      console.error('Backend error:', error);
+      alert('Backend fout: ' + (error instanceof Error ? error.message : 'Onbekende fout'));
     } finally {
       setIsAnalyzing(false);
     }


### PR DESCRIPTION
## 🚀 Fix 400/405 API Endpoint Error

**Problem:** Frontend was making direct fetch calls to `/input_task` but backend expects `/api/input_task`

**Solution:** Replace direct fetch with `apiService.submitInputTask()` which uses correct endpoint

### Changes Made:
- Import `apiService` in App.tsx
- Replace manual fetch call with `apiService.submitInputTask()`
- Simplify error handling since apiService handles HTTP errors

### Testing:
- ✅ Branch pushed successfully
- ✅ Ready for deployment via GitHub Actions
- 🔄 Will test on live frontend after deployment

**Link to Devin run:** https://app.devin.ai/sessions/71a11b3944d14319aa12f55f4720194d
**Requested by:** @somc-ai