### PR TITLE
fix: resolve Azure Container Apps deployment failure

### DIFF
--- a/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
+++ b/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build and push container image to registry
         uses: azure/container-apps-deploy-action@v2
         with:
-          appSourcePath: ${{ github.workspace }}src/backend/Dockerfile.azure
+          appSourcePath: ${{ github.workspace }}/src/backend/Dockerfile.azure
           _dockerfilePathKey_: _dockerfilePath_
           _targetLabelKey_: _targetLabel_
           registryUrl: ca2a76f03945acr.azurecr.io


### PR DESCRIPTION
## Problem
The GitHub Actions deployment to Azure Container Apps is failing because of a missing slash in the workflow file path.

## Solution
Fixed the `appSourcePath` in the workflow file from:
```
${{ github.workspace }}src/backend/Dockerfile.azure
```
To:
```
${{ github.workspace }}/src/backend/Dockerfile.azure
```

## Impact
This resolves the deployment failure and allows the API endpoint fix from PR #19 to be properly deployed to Azure Container Apps.

## Testing
- [x] Workflow file syntax is correct
- [ ] Deployment succeeds after merge
- [ ] Live application works without 400/405 errors

**Link to Devin run:** https://app.devin.ai/sessions/71a11b3944d14319aa12f55f4720194d
**Requested by:** @somc-ai