### PR TITLE
fix: resolve Dockerfile issues preventing Azure deployment

### DIFF
--- a/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
+++ b/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build and push container image to registry
         uses: azure/container-apps-deploy-action@v2
         with:
-          appSourcePath: ${{ github.workspace }}src/backend/Dockerfile.azure
+          appSourcePath: ${{ github.workspace }}/src/backend/Dockerfile.azure
           _dockerfilePathKey_: _dockerfilePath_
           _targetLabelKey_: _targetLabel_
           registryUrl: ca2a76f03945acr.azurecr.io

--- a/src/backend/Dockerfile.azure
+++ b/src/backend/Dockerfile.azure
@@ -14,11 +14,11 @@ RUN pip install --no-cache-dir --upgrade pip && \
 # Copy all source files
 COPY . /app
 
-# Set correct permissions before switching user
-RUN chown -R app:app /app
-
 # Create a non-root user for security
 RUN useradd --create-home --shell /bin/bash app
+
+# Set correct permissions after creating user
+RUN chown -R app:app /app
 USER app
 
 # Set working directory and Python path
@@ -27,8 +27,8 @@ ENV PYTHONPATH=/app
 
 EXPOSE 8000
 
-# Health check
+# Health check (using python instead of curl since curl not available in slim image)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8000/health || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
 CMD ["uvicorn", "app_kernel:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]


### PR DESCRIPTION
## Problem
The Azure Container Apps deployment continues to fail due to Dockerfile issues:
- User creation order: trying to chown before creating the user
- Healthcheck using curl which is not available in python:3.12-slim base image

## Solution
- Reorder user creation before chown to fix permission error
- Replace curl healthcheck with Python urllib (curl not available in slim image)

## Impact
This should resolve the container build failures in Azure Container Apps and allow the API endpoint fix from PR #19 to be properly deployed.

## Testing
- [x] Dockerfile syntax is correct
- [ ] Container builds successfully in Azure
- [ ] API endpoint fix is deployed
- [ ] Live application works without 400/405 errors

**Link to Devin run:** https://app.devin.ai/sessions/71a11b3944d14319aa12f55f4720194d
**Requested by:** @somc-ai