### PR TITLE
Add Azure OpenAI API key authentication for Container Apps

### DIFF
--- a/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
+++ b/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
@@ -46,6 +46,7 @@ jobs:
             AZURE_OPENAI_ENDPOINT=https://somc-ai-gov-openai.openai.azure.com/
             AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4o
             AZURE_OPENAI_API_VERSION=2024-08-01-preview
+            AZURE_OPENAI_API_KEY=${{ secrets.AZURE_OPENAI_API_KEY }}
             AZURE_AI_SUBSCRIPTION_ID=05cc117e-29ea-49f3-9428-c5d042340a91
             AZURE_AI_RESOURCE_GROUP=rg-info-2259
             AZURE_AI_PROJECT_NAME=ai-project-default


### PR DESCRIPTION
This PR adds the missing AZURE_OPENAI_API_KEY environment variable to the Container Apps deployment workflow.

## Changes
- Add AZURE_OPENAI_API_KEY from GitHub secrets to environmentVariables in the workflow
- This enables API key authentication as fallback for DefaultAzureCredential
- Resolves 400 authentication errors when backend tries to access Azure OpenAI

## Context
The backend supports both API key and Managed Identity authentication patterns. When DefaultAzureCredential fails (due to incomplete Managed Identity setup), the backend falls back to API key authentication if AZURE_OPENAI_API_KEY is provided.

This fixes the 400 error: "DefaultAzureCredential failed to retrieve a token from the included credentials" that occurs when users submit scenarios through the frontend.

## Testing
- ✅ Frontend successfully loads agents from /api/agent-tools (200 status)
- ❌ Frontend gets 400 error on /api/input_task due to missing API key
- 🔄 After this PR: API key authentication should resolve the 400 error

Link to Devin run: https://app.devin.ai/sessions/71a11b3944d14319aa12f55f4720194d
Requested by: @somc-ai