### PR TITLE
Fix Azure authentication using AZURE_CREDENTIALS secret

### DIFF
--- a/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
+++ b/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
@@ -27,9 +27,7 @@ jobs:
       - name: Azure Login
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.BACKENDAIAGENTSGOV_AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.BACKENDAIAGENTSGOV_AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.BACKENDAIAGENTSGOV_AZURE_SUBSCRIPTION_ID }}
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Build and push container image to registry
         uses: azure/container-apps-deploy-action@v2
@@ -47,9 +45,9 @@ jobs:
             AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4o
             AZURE_OPENAI_API_VERSION=2024-08-01-preview
             AZURE_OPENAI_API_KEY=${{ secrets.AZURE_OPENAI_API_KEY }}
-            AZURE_TENANT_ID=${{ secrets.BACKENDAIAGENTSGOV_AZURE_TENANT_ID }}
-            AZURE_CLIENT_ID=${{ secrets.BACKENDAIAGENTSGOV_AZURE_CLIENT_ID }}
-            AZURE_CLIENT_SECRET=${{ secrets.BACKENDAIAGENTSGOV_AZURE_CLIENT_SECRET }}
+            AZURE_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
+            AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
+            AZURE_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
             AZURE_AI_SUBSCRIPTION_ID=05cc117e-29ea-49f3-9428-c5d042340a91
             AZURE_AI_RESOURCE_GROUP=rg-info-2259
             AZURE_AI_PROJECT_NAME=ai-project-default


### PR DESCRIPTION
This PR fixes the Azure authentication issues by using the existing AZURE_CREDENTIALS secret instead of the missing BACKENDAIAGENTSGOV_AZURE_CLIENT_SECRET.

## Changes
- Replace individual BACKENDAIAGENTSGOV_* secrets with standard AZURE_CREDENTIALS for Azure login
- Use AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET environment variables from existing secrets
- This fixes DefaultAzureCredential authentication failures in Container Apps
- Resolves 400 errors by providing proper Azure service authentication

## Context
The previous deployment was failing because BACKENDAIAGENTSGOV_AZURE_CLIENT_SECRET was missing from GitHub secrets, causing DefaultAzureCredential authentication to fail. This PR uses the existing AZURE_CREDENTIALS secret which contains all required authentication information.

Link to Devin run: https://app.devin.ai/sessions/71a11b3944d14319aa12f55f4720194d
Requested by: @somc-ai