### PR TITLE
Fix Container Apps authentication by removing non-existent secrets

### DIFF
--- a/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
+++ b/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
@@ -45,9 +45,6 @@ jobs:
             AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4o
             AZURE_OPENAI_API_VERSION=2024-08-01-preview
             AZURE_OPENAI_API_KEY=${{ secrets.AZURE_OPENAI_API_KEY }}
-            AZURE_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
-            AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
-            AZURE_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
             AZURE_AI_SUBSCRIPTION_ID=05cc117e-29ea-49f3-9428-c5d042340a91
             AZURE_AI_RESOURCE_GROUP=rg-info-2259
             AZURE_AI_PROJECT_NAME=ai-project-default


### PR DESCRIPTION
This PR fixes the persistent 400 DefaultAzureCredential errors by removing references to non-existent GitHub secrets.

## Problem
The workflow was referencing `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET` secrets that do not exist in the GitHub repository, causing the Container Apps deployment to fail with authentication errors.

## Solution
- Remove the non-existent secret references from environment variables
- Container Apps will use Managed Identity for Azure service authentication
- `AZURE_OPENAI_API_KEY` is sufficient for OpenAI authentication

## Testing
After deployment, the `/api/input_task` endpoint should work without 400 DefaultAzureCredential errors.

Link to Devin run: https://app.devin.ai/sessions/71a11b3944d14319aa12f55f4720194d
Requested by: @somc-ai