### PR TITLE
Fix Azure authentication by extracting credentials from AZURE_CREDENTIALS secret

### DIFF
--- a/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
+++ b/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
@@ -29,6 +29,13 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Extract Azure credentials
+        id: azure-creds
+        run: |
+          echo "AZURE_TENANT_ID=$(echo '${{ secrets.AZURE_CREDENTIALS }}' | jq -r '.tenantId')" >> $GITHUB_OUTPUT
+          echo "AZURE_CLIENT_ID=$(echo '${{ secrets.AZURE_CREDENTIALS }}' | jq -r '.clientId')" >> $GITHUB_OUTPUT
+          echo "AZURE_CLIENT_SECRET=$(echo '${{ secrets.AZURE_CREDENTIALS }}' | jq -r '.clientSecret')" >> $GITHUB_OUTPUT
+
       - name: Build and push container image to registry
         uses: azure/container-apps-deploy-action@v2
         with:
@@ -45,6 +52,9 @@ jobs:
             AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4o
             AZURE_OPENAI_API_VERSION=2024-08-01-preview
             AZURE_OPENAI_API_KEY=${{ secrets.AZURE_OPENAI_API_KEY }}
+            AZURE_TENANT_ID=${{ steps.azure-creds.outputs.AZURE_TENANT_ID }}
+            AZURE_CLIENT_ID=${{ steps.azure-creds.outputs.AZURE_CLIENT_ID }}
+            AZURE_CLIENT_SECRET=${{ steps.azure-creds.outputs.AZURE_CLIENT_SECRET }}
             AZURE_AI_SUBSCRIPTION_ID=05cc117e-29ea-49f3-9428-c5d042340a91
             AZURE_AI_RESOURCE_GROUP=rg-info-2259
             AZURE_AI_PROJECT_NAME=ai-project-default


### PR DESCRIPTION
This PR resolves the persistent 400 DefaultAzureCredential authentication failures by properly extracting Azure credentials from the existing AZURE_CREDENTIALS secret.

## Problem
The Container Apps deployment was failing with DefaultAzureCredential errors because the environment variables AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET were not available, even though the AZURE_CREDENTIALS secret contains this information in JSON format.

## Solution
- Add workflow step to extract tenantId, clientId, and clientSecret from the AZURE_CREDENTIALS JSON secret
- Pass the extracted values as environment variables to the Container Apps deployment
- This provides the proper authentication context for DefaultAzureCredential to work in the Container Apps environment

## Expected Result
After deployment, the `/api/input_task` endpoint should work without 400 DefaultAzureCredential errors, enabling the complete AI Agent workflow.

Link to Devin run: https://app.devin.ai/sessions/71a11b3944d14319aa12f55f4720194d
Requested by: @somc-ai