### PR TITLE
Fix Container Apps environment variables YAML syntax for Azure authentication

### DIFF
--- a/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
+++ b/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
@@ -57,7 +57,7 @@ jobs:
           containerAppName: backend-aiagents-gov
           resourceGroup: rg-info-2259
           imageToBuild: ca2a76f03945acr.azurecr.io/backend-aiagents-gov:${{ github.sha }}
-          environmentVariables: |
+          environmentVariables: >-
             AZURE_OPENAI_ENDPOINT=https://somc-ai-gov-openai.openai.azure.com/
             AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4o
             AZURE_OPENAI_API_VERSION=2024-08-01-preview


### PR DESCRIPTION
This PR fixes the YAML syntax for environment variables in the GitHub Actions workflow to ensure proper application to Azure Container Apps.

## Changes
- Change environmentVariables from `|` to `>-` syntax for proper YAML parsing
- This should resolve the persistent DefaultAzureCredential authentication failures
- Environment variables should now properly reach Container Apps runtime

## Context
Despite successful GitHub Actions deployments, the Container Apps are still showing "EnvironmentCredential: Environment variables are not fully configured" errors. This YAML syntax fix should ensure the environment variables are properly applied during deployment.

Link to Devin run: https://app.devin.ai/sessions/71a11b3944d14319aa12f55f4720194d
Requested by: @somc-ai