### PR TITLE
Fix Container Apps environment variables using Azure CLI direct update

### DIFF
--- a/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
+++ b/.github/workflows/backend-aiagents-gov-AutoDeployTrigger-66d7852e-1596-4a66-824a-0498253f1e64.yml
@@ -57,22 +57,31 @@ jobs:
           containerAppName: backend-aiagents-gov
           resourceGroup: rg-info-2259
           imageToBuild: ca2a76f03945acr.azurecr.io/backend-aiagents-gov:${{ github.sha }}
-          environmentVariables: >-
-            AZURE_OPENAI_ENDPOINT=https://somc-ai-gov-openai.openai.azure.com/
-            AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4o
-            AZURE_OPENAI_API_VERSION=2024-08-01-preview
-            AZURE_OPENAI_API_KEY=${{ secrets.AZURE_OPENAI_API_KEY }}
-            AZURE_TENANT_ID=${{ steps.azure-creds.outputs.AZURE_TENANT_ID }}
-            AZURE_CLIENT_ID=${{ steps.azure-creds.outputs.AZURE_CLIENT_ID }}
-            AZURE_CLIENT_SECRET=${{ steps.azure-creds.outputs.AZURE_CLIENT_SECRET }}
-            AZURE_AI_SUBSCRIPTION_ID=05cc117e-29ea-49f3-9428-c5d042340a91
-            AZURE_AI_RESOURCE_GROUP=rg-info-2259
-            AZURE_AI_PROJECT_NAME=ai-project-default
-            AZURE_AI_AGENT_ENDPOINT=https://somc-ai-gov-openai.openai.azure.com/
-            COSMOSDB_ENDPOINT=https://cosmos-somc-ai-gov.documents.azure.com:443/
-            COSMOSDB_DATABASE=macae
-            COSMOSDB_CONTAINER=memory
-            BACKEND_API_URL=https://backend-aiagents-gov.victoriouscoast-531c9ceb.westeurope.azurecontainerapps.io
-            FRONTEND_SITE_NAME=https://frontend-aiagents-gov.victoriouscoast-531c9ceb.westeurope.azurecontainerapps.io
+
+      - name: Update Container App environment variables using Azure CLI
+        run: |
+          echo "Setting environment variables directly on Container App..."
+          az containerapp update \
+            --name backend-aiagents-gov \
+            --resource-group rg-info-2259 \
+            --set-env-vars \
+              AZURE_OPENAI_ENDPOINT=https://somc-ai-gov-openai.openai.azure.com/ \
+              AZURE_OPENAI_DEPLOYMENT_NAME=gpt-4o \
+              AZURE_OPENAI_API_VERSION=2024-08-01-preview \
+              AZURE_OPENAI_API_KEY="${{ secrets.AZURE_OPENAI_API_KEY }}" \
+              AZURE_TENANT_ID="${{ steps.azure-creds.outputs.AZURE_TENANT_ID }}" \
+              AZURE_CLIENT_ID="${{ steps.azure-creds.outputs.AZURE_CLIENT_ID }}" \
+              AZURE_CLIENT_SECRET="${{ steps.azure-creds.outputs.AZURE_CLIENT_SECRET }}" \
+              AZURE_AI_SUBSCRIPTION_ID=05cc117e-29ea-49f3-9428-c5d042340a91 \
+              AZURE_AI_RESOURCE_GROUP=rg-info-2259 \
+              AZURE_AI_PROJECT_NAME=ai-project-default \
+              AZURE_AI_AGENT_ENDPOINT=https://somc-ai-gov-openai.openai.azure.com/ \
+              COSMOSDB_ENDPOINT=https://cosmos-somc-ai-gov.documents.azure.com:443/ \
+              COSMOSDB_DATABASE=macae \
+              COSMOSDB_CONTAINER=memory \
+              BACKEND_API_URL=https://backend-aiagents-gov.victoriouscoast-531c9ceb.westeurope.azurecontainerapps.io \
+              FRONTEND_SITE_NAME=https://frontend-aiagents-gov.victoriouscoast-531c9ceb.westeurope.azurecontainerapps.io
+          
+          echo "Environment variables set successfully. Container App will restart automatically."
 
 


### PR DESCRIPTION
This PR fixes the persistent DefaultAzureCredential authentication failures by using Azure CLI to directly set environment variables on the Container Apps.

## Changes
- Replace environmentVariables parameter with explicit `az containerapp update --set-env-vars` command
- This ensures environment variables are properly applied to Container Apps runtime
- Container App will restart automatically after environment variables are set

## Context
Despite multiple attempts with different YAML syntax approaches, the environment variables were not reaching the Container Apps runtime. This direct Azure CLI approach should resolve the persistent "EnvironmentCredential: Environment variables are not fully configured" errors.

Link to Devin run: https://app.devin.ai/sessions/71a11b3944d14319aa12f55f4720194d
Requested by: @somc-ai